### PR TITLE
Reset terminal color to default at end of output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,8 @@ pub fn print_msg<P: AsRef<Path>>(
   )?;
   writeln!(&mut buffer, "Thank you kindly!")?;
 
+  buffer.reset()?;
+
   stderr.print(&buffer).unwrap();
   Ok(())
 }


### PR DESCRIPTION
This is a 🐛 bug fix.

Currently the terminal color is set to red at the beginning of the output.
However it is never reset again at the end of the output.
This causes prompts and future commands that don't set the color to be red.
This PR adds the missing reset.

## Checklist
- [x] tests pass

## Semver Changes
patch version