### PR TITLE
docs + .gitignore fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ npm-debug.log*
 .DS_Store
 .nyc_output
 Cargo.lock
-target/
+target

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![crates.io version][1]][2] [![build status][3]][4]
 [![downloads][5]][6] [![docs.rs docs][7]][8]
 
-Panic messages for humans. Replacement for
-[`std::panic::catch_unwind`](https://doc.rust-lang.org/std/panic/fn.catch_unwind.html)
+Panic messages for humans. Handles panics by calling
+[`std::panic::set_hook`](https://doc.rust-lang.org/std/panic/fn.set_hook.html)
 to make errors nice for humans.
 
 - [Documentation][8]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Panic messages for humans
 //!
-//! Replacement for
-//! [`std::panic::catch_unwind`](https://doc.rust-lang.org/std/panic/fn.catch_unwind.html)
+//! Handles panics by calling
+//! [`std::panic::set_hook`](https://doc.rust-lang.org/std/panic/fn.set_hook.html)
 //! to make errors nice for humans.
 //!
 //! ## Why?


### PR DESCRIPTION
The docs refer to catch_unwind while this library actually uses set_hook. Looks like it used to use catch_unwind and was never changed.

By removing the / at the end of target then .gitignore will handle both folders and symlinks.
This is useful as I symlink my target directories to make syncing projects between machines faster.

This is mostly a 🔦 documentation change

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is changed or added

## Semver Changes
patch version
