### PR TITLE
Changing the links of badges to rust-clique/...

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ $ cargo add human-panic
 
 [1]: https://img.shields.io/crates/v/human-panic.svg?style=flat-square
 [2]: https://crates.io/crates/human-panic
-[3]: https://img.shields.io/travis/yoshuawuyts/human-panic.svg?style=flat-square
-[4]: https://travis-ci.org/yoshuawuyts/human-panic
+[3]: https://img.shields.io/travis/rust-clique/human-panic.svg?style=flat-square
+[4]: https://travis-ci.org/rust-clique/human-panic
 [5]: https://img.shields.io/crates/d/human-panic.svg?style=flat-square
 [6]: https://crates.io/crates/human-panic
 [7]: https://docs.rs/human-panic/badge.svg


### PR DESCRIPTION
We moved the project to the rust-clique organisation but never updated those links :speak_no_evil: 

This is a trivial change :wink: 