### PR TITLE
Including original-sin (panic) in report

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,7 @@
 //! pretty great at safety, it's not unheard of to access the wrong index in a
 //! vector or have an assert fail somewhere.
 //!
-//! When an error eventually occurs, you proba
-//! #[cfg(feature = "nightly")]bly will want to know about it. So
+//! When an error eventually occurs, you probably will want to know about it. So
 //! instead of just providing an error message on the command line, we can create a
 //! call to action for people to submit a report.
 //!
@@ -76,8 +75,7 @@ pub struct Metadata {
 
 /// `human-panic` initialisation macro
 ///
-/// You can either call this macro with no arguments `setup_pan
-/// #[cfg(feature = "nightly")]ic!()` or
+/// You can either call this macro with no arguments `setup_panic!()` or
 /// with a Metadata struct, if you don't want the error message to display
 /// the values used in your `Cargo.toml` file.
 ///
@@ -132,7 +130,8 @@ macro_rules! setup_panic {
 }
 
 
-#[cfg(feature = "nightly")]/// Utility function that prints a message to our human users
+/// Utility function that prints a message to our human users
+#[cfg(feature = "nightly")]
 pub fn print_msg<P: AsRef<Path>>(
   file_path: Option<P>,
   meta: &Metadata,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@
 
 #![cfg_attr(feature = "nightly", deny(missing_docs))]
 #![cfg_attr(feature = "nightly", feature(external_doc))]
+#![cfg_attr(feature = "nightly", feature(panic_info_message))]
 
 extern crate backtrace;
 #[macro_use]
@@ -179,6 +180,10 @@ pub fn print_msg<P: AsRef<Path>>(
 /// Utility function which will handle dumping information to disk
 pub fn handle_dump(meta: &Metadata, panic_info: &PanicInfo) -> Option<PathBuf> {
   let mut expl = String::new();
+  let cause = match panic_info.message() {
+    Some(m) => format!("{}", m),
+    None => "Unknown".into(),
+  };
 
   let payload = panic_info.payload().downcast_ref::<&str>();
   if let Some(payload) = payload {
@@ -194,7 +199,7 @@ pub fn handle_dump(meta: &Metadata, panic_info: &PanicInfo) -> Option<PathBuf> {
     None => expl.push_str("Panic location unknown.\n"),
   }
 
-  let report = Report::new(&meta.name, &meta.version, Method::Panic, expl);
+  let report = Report::new(&meta.name, &meta.version, Method::Panic, expl, cause);
 
   match report.persist() {
     Ok(f) => Some(f),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-//! Panic messages for humans
+//! Panic message
+//! #[cfg(feature = "nightly")]s for humans
 //!
 //! Handles panics by calling
 //! [`std::panic::set_hook`](https://doc.rust-lang.org/std/panic/fn.set_hook.html)
@@ -9,7 +10,8 @@
 //! pretty great at safety, it's not unheard of to access the wrong index in a
 //! vector or have an assert fail somewhere.
 //!
-//! When an error eventually occurs, you probably will want to know about it. So
+//! When an error eventually occurs, you proba
+//! #[cfg(feature = "nightly")]bly will want to know about it. So
 //! instead of just providing an error message on the command line, we can create a
 //! call to action for people to submit a report.
 //!
@@ -74,7 +76,8 @@ pub struct Metadata {
 
 /// `human-panic` initialisation macro
 ///
-/// You can either call this macro with no arguments `setup_panic!()` or
+/// You can either call this macro with no arguments `setup_pan
+/// #[cfg(feature = "nightly")]ic!()` or
 /// with a Metadata struct, if you don't want the error message to display
 /// the values used in your `Cargo.toml` file.
 ///
@@ -102,6 +105,7 @@ macro_rules! setup_panic {
       let file_path = handle_dump(&$meta, info);
 
       print_msg(file_path, &$meta)
+      #[cfg(feature = "nightly")]
         .expect("human-panic: printing error message to console failed");
     }));
   };
@@ -121,12 +125,14 @@ macro_rules! setup_panic {
       let file_path = handle_dump(&meta, info);
 
       print_msg(file_path, &meta)
+      #[cfg(feature = "nightly")]
         .expect("human-panic: printing error message to console failed");
     }));
   };
 }
 
-/// Utility function that prints a message to our human users
+
+#[cfg(feature = "nightly")]/// Utility function that prints a message to our human users
 pub fn print_msg<P: AsRef<Path>>(
   file_path: Option<P>,
   meta: &Metadata,
@@ -180,10 +186,14 @@ pub fn print_msg<P: AsRef<Path>>(
 /// Utility function which will handle dumping information to disk
 pub fn handle_dump(meta: &Metadata, panic_info: &PanicInfo) -> Option<PathBuf> {
   let mut expl = String::new();
+  #[cfg(feature = "nightly")]
   let cause = match panic_info.message() {
     Some(m) => format!("{}", m),
     None => "Unknown".into(),
   };
+
+  #[cfg(not(feature = "nightly"))]
+  let cause = String::from("Not supported by application");
 
   let payload = panic_info.payload().downcast_ref::<&str>();
   if let Some(payload) = payload {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,6 @@ macro_rules! setup_panic {
   };
 }
 
-
 /// Utility function that prints a message to our human users
 pub fn print_msg<P: AsRef<Path>>(
   file_path: Option<P>,
@@ -188,7 +187,8 @@ pub fn handle_dump(meta: &Metadata, panic_info: &PanicInfo) -> Option<PathBuf> {
   };
 
   #[cfg(not(feature = "nightly"))]
-  let cause = String::from("Error cause could not be determined by the application.");
+  let cause =
+    String::from("Error cause could not be determined by the application.");
 
   let payload = panic_info.payload().downcast_ref::<&str>();
   if let Some(payload) = payload {
@@ -204,7 +204,8 @@ pub fn handle_dump(meta: &Metadata, panic_info: &PanicInfo) -> Option<PathBuf> {
     None => expl.push_str("Panic location unknown.\n"),
   }
 
-  let report = Report::new(&meta.name, &meta.version, Method::Panic, expl, cause);
+  let report =
+    Report::new(&meta.name, &meta.version, Method::Panic, expl, cause);
 
   match report.persist() {
     Ok(f) => Some(f),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ pub fn handle_dump(meta: &Metadata, panic_info: &PanicInfo) -> Option<PathBuf> {
   };
 
   #[cfg(not(feature = "nightly"))]
-  let cause = String::from("Not supported by application");
+  let cause = String::from("Error cause could not be determined by the application.");
 
   let payload = panic_info.payload().downcast_ref::<&str>();
   if let Some(payload) = payload {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-//! Panic message
-//! #[cfg(feature = "nightly")]s for humans
+//! Panic messages for humans
 //!
 //! Handles panics by calling
 //! [`std::panic::set_hook`](https://doc.rust-lang.org/std/panic/fn.set_hook.html)
@@ -103,7 +102,6 @@ macro_rules! setup_panic {
       let file_path = handle_dump(&$meta, info);
 
       print_msg(file_path, &$meta)
-      #[cfg(feature = "nightly")]
         .expect("human-panic: printing error message to console failed");
     }));
   };
@@ -123,7 +121,6 @@ macro_rules! setup_panic {
       let file_path = handle_dump(&meta, info);
 
       print_msg(file_path, &meta)
-      #[cfg(feature = "nightly")]
         .expect("human-panic: printing error message to console failed");
     }));
   };
@@ -131,7 +128,6 @@ macro_rules! setup_panic {
 
 
 /// Utility function that prints a message to our human users
-#[cfg(feature = "nightly")]
 pub fn print_msg<P: AsRef<Path>>(
   file_path: Option<P>,
   meta: &Metadata,

--- a/src/report.rs
+++ b/src/report.rs
@@ -23,6 +23,7 @@ pub struct Report {
   operating_system: Cow<'static, str>,
   crate_version: String,
   explanation: String,
+  cause: String,
   method: Method,
   backtrace: String,
 }
@@ -34,6 +35,7 @@ impl Report {
     version: &str,
     method: Method,
     explanation: String,
+    cause: String,
   ) -> Self {
     let operating_system = if cfg!(windows) {
       "windows".into()
@@ -50,6 +52,7 @@ impl Report {
       operating_system,
       method,
       explanation,
+      cause,
       backtrace,
     }
   }


### PR DESCRIPTION
**Choose one:** This a 🐛 bug fix

Including original panic-cause in report

Okay so this PR is a bit of a dilemma.
The API we need to get the original panic message isn't stable
and requires a feature flag.
We can conditionally enable the feature flag for nightly users
but that doesn't quite deal with the problem of what to do
when someone is using `human-panic` on stable.

As far as I can see there's no other API to get that information?
We could always just gate it all away behind the `nightly` feature
and just ommit a static "not supported" or something when running
on stable.

The tests pass (provided you pass `--features nightly` for now).
Wanted to open this PR to discuss how to proceed :)

- [x] tests pass
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added

This fixes #40

This should be a minor bump I believe?

The `Report` struct isn't exported so adding a field there isn't gonna make a difference 🤷