### PR TITLE
Pinning clippy on 1.29.1 stable to avoid more uneccesary CI breakage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,12 @@ matrix: # additional tests
   - rust: nightly
     script: |
        cargo test --all --features nightly
-  - rust: nightly-2018-04-15
-    env: CLIPPY_VERS="0.0.194"
-    before_script: |
-      [[ "$(cargo +nightly-2018-04-15 clippy --version)" != "$CLIPPY_VERS" ]] && \
-      cargo +nightly-2018-04-15 install clippy --vers "$CLIPPY_VERS" --force || true
-    script: |
-      cargo +nightly-2018-04-15 clippy --all -- -D warnings
-  - rust: 1.25.0  # `stable`: Locking down for consistent behavior
-    env: RUSTFMT=yes_please
-    install:
-    - rustup component add rustfmt-preview
-    script:
-    - cargo fmt --all -- --write-mode=diff
+  - rust: 1.29.1
+    env: CLIPPY=YESPLEASE
+    before_script: rustup component add clippy-preview
+    script: cargo clippy --all -- -D warnings
+  - rust: 1.29.1
+    env: RUSTFMT=YESPLEASE
+    before_script: rustup component add rustfmt-preview
+    script: cargo fmt --all -- --check
 cache: cargo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,8 +94,8 @@ pub struct Metadata {
 #[macro_export]
 macro_rules! setup_panic {
   ($meta:expr) => {
-    use $crate::{handle_dump, print_msg, Metadata};
     use std::panic::{self, PanicInfo};
+    use $crate::{handle_dump, print_msg, Metadata};
 
     panic::set_hook(Box::new(move |info: &PanicInfo| {
       let file_path = handle_dump(&$meta, info);
@@ -106,8 +106,8 @@ macro_rules! setup_panic {
   };
 
   () => {
-    use $crate::{handle_dump, print_msg, Metadata};
     use std::panic::{self, PanicInfo};
+    use $crate::{handle_dump, print_msg, Metadata};
 
     let meta = Metadata {
       version: env!("CARGO_PKG_VERSION").into(),


### PR DESCRIPTION
This a 🐛 bug fix.

The clippy-preview works on the stable channel now so we can pin it on 1.29.1 and use it for lints and formatting without having to bump clippy and or nightly every so often.

## Checklist
- [ ] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
