### PR TITLE
Only display message for humans (implementing #48)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,35 +94,51 @@ pub struct Metadata {
 #[macro_export]
 macro_rules! setup_panic {
   ($meta:expr) => {
+    #[allow(unused_imports)]
+    use $crate::{handle_dump, print_msg, Metadata};
+    #[allow(unused_imports)]
     use std::panic::{self, PanicInfo};
     use $crate::{handle_dump, print_msg, Metadata};
 
-    panic::set_hook(Box::new(move |info: &PanicInfo| {
-      let file_path = handle_dump(&$meta, info);
-
-      print_msg(file_path, &$meta)
-        .expect("human-panic: printing error message to console failed");
-    }));
+    #[cfg(not(debug_assertions))]
+    match ::std::env::var("RUST_BACKTRACE") {
+      Err(_) => {
+        panic::set_hook(Box::new(move |info: &PanicInfo| {
+          let file_path = handle_dump(&$meta, info);
+          print_msg(file_path, &$meta)
+            .expect("human-panic: printing error message to console failed");
+        }));
+      },
+      Ok(_) => {},
+    }
   };
 
   () => {
+    #[allow(unused_imports)]
+    use $crate::{handle_dump, print_msg, Metadata};
+    #[allow(unused_imports)]
     use std::panic::{self, PanicInfo};
     use $crate::{handle_dump, print_msg, Metadata};
 
-    let meta = Metadata {
-      version: env!("CARGO_PKG_VERSION").into(),
-      name: env!("CARGO_PKG_NAME").into(),
-      authors: env!("CARGO_PKG_AUTHORS").replace(":", ", ").into(),
-      homepage: env!("CARGO_PKG_HOMEPAGE").into(),
-    };
+    #[cfg(not(debug_assertions))]
+    match ::std::env::var("RUST_BACKTRACE") {
+      Err(_) => {
+        let meta = Metadata {
+          version: env!("CARGO_PKG_VERSION").into(),
+          name: env!("CARGO_PKG_NAME").into(),
+          authors: env!("CARGO_PKG_AUTHORS").replace(":", ", ").into(),
+          homepage: env!("CARGO_PKG_HOMEPAGE").into(),
+        };
 
-    panic::set_hook(Box::new(move |info: &PanicInfo| {
-      let file_path = handle_dump(&meta, info);
-
-      print_msg(file_path, &meta)
-        .expect("human-panic: printing error message to console failed");
-    }));
-  };
+        panic::set_hook(Box::new(move |info: &PanicInfo| {
+          let file_path = handle_dump(&meta, info);
+          print_msg(file_path, &meta)
+            .expect("human-panic: printing error message to console failed");
+        }));
+      },
+      Ok(_) => {},
+    }
+  }
 }
 
 /// Utility function that prints a message to our human users

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,9 +95,8 @@ pub struct Metadata {
 macro_rules! setup_panic {
   ($meta:expr) => {
     #[allow(unused_imports)]
-    use $crate::{handle_dump, print_msg, Metadata};
-    #[allow(unused_imports)]
     use std::panic::{self, PanicInfo};
+    #[allow(unused_imports)]
     use $crate::{handle_dump, print_msg, Metadata};
 
     #[cfg(not(debug_assertions))]
@@ -108,16 +107,15 @@ macro_rules! setup_panic {
           print_msg(file_path, &$meta)
             .expect("human-panic: printing error message to console failed");
         }));
-      },
-      Ok(_) => {},
+      }
+      Ok(_) => {}
     }
   };
 
   () => {
     #[allow(unused_imports)]
-    use $crate::{handle_dump, print_msg, Metadata};
-    #[allow(unused_imports)]
     use std::panic::{self, PanicInfo};
+    #[allow(unused_imports)]
     use $crate::{handle_dump, print_msg, Metadata};
 
     #[cfg(not(debug_assertions))]
@@ -135,10 +133,10 @@ macro_rules! setup_panic {
           print_msg(file_path, &meta)
             .expect("human-panic: printing error message to console failed");
         }));
-      },
-      Ok(_) => {},
+      }
+      Ok(_) => {}
     }
-  }
+  };
 }
 
 /// Utility function that prints a message to our human users

--- a/tests/custom-panic/tests/integration.rs
+++ b/tests/custom-panic/tests/integration.rs
@@ -1,8 +1,8 @@
 extern crate assert_cli;
 
 #[test]
-fn integration() {
-  assert_cli::Assert::main_binary()
+fn release() {
+  assert_cli::Assert::command(&["cargo", "run", "--release"])
     .stderr()
     .contains("custom-panic-test")
     .stderr()
@@ -14,3 +14,13 @@ fn integration() {
     .fails_with(101)
     .unwrap();
 }
+
+#[test]
+fn debug() {
+  assert_cli::Assert::command(&["cargo", "run"])
+    .stderr()
+    .contains("OMG EVERYTHING IS ON FIRE!!!")
+    .fails_with(101)
+    .unwrap();
+}
+

--- a/tests/custom-panic/tests/integration.rs
+++ b/tests/custom-panic/tests/integration.rs
@@ -23,4 +23,3 @@ fn debug() {
     .fails_with(101)
     .unwrap();
 }
-

--- a/tests/single-panic/tests/integration.rs
+++ b/tests/single-panic/tests/integration.rs
@@ -1,8 +1,8 @@
 extern crate assert_cli;
 
 #[test]
-fn integration() {
-  assert_cli::Assert::main_binary()
+fn release() {
+  assert_cli::Assert::command(&["cargo", "run", "--release"])
     .stderr()
     .contains("single-panic-test")
     .stderr()
@@ -12,3 +12,13 @@ fn integration() {
     .fails_with(101)
     .unwrap();
 }
+
+#[test]
+fn debug() {
+  assert_cli::Assert::command(&["cargo", "run"])
+    .stderr()
+    .contains("OMG EVERYTHING IS ON FIRE!!!")
+    .fails_with(101)
+    .unwrap();
+}
+

--- a/tests/single-panic/tests/integration.rs
+++ b/tests/single-panic/tests/integration.rs
@@ -21,4 +21,3 @@ fn debug() {
     .fails_with(101)
     .unwrap();
 }
-


### PR DESCRIPTION
This is a 🙋 feature.

## Overview

The general rationale for this is documented in #48.
This PR implements the required behaviour. A `human-panic`
message will only be displayed if two conditions are met

1. The program is **not** running in `DEBUG` mode
2. `RUST_BACKTRACE` is **not** set as an env variable

This PR also adjusts the tests to check for both present
and non-present `human-panic` messages. 

---

There are two things missing

- [ ] Properly document this change!
- A test that checks for the `RUST_BACKTRACE` override
  behaviour when running in `RELEASE` mode. This is currently
  not easy to do with `assert_CLI` (there might be more PRs 🙂)

## Checklist

- [x] tests pass
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Semver change

Now, this is a matter of how you _define_ a version breakage.
SemVer is ambigous when it comes to what is and isn't a breakage,
for example, if people are depending on human-panic messages to be
present to parse things from logs then any tool that updates
`human-panic` while we are changing behaviour will break.

In the code, this is at most a `minor` bump. But seeing as we're
also looking at things to add for a `2.0` release, we might want to
put it on the tracking issue (#46).

Either way, we need to document this change because it might have
a large impact on people who depend on the stdout message to be
present.